### PR TITLE
Gateway now supports handling multiple services

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
 libraryDependencies ++= Seq(
   "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0-pre5",
-  "beyondthelines"         %% "grpcgatewaygenerator" % "0.0.3"
+  "beyondthelines"         %% "grpcgatewaygenerator" % "0.0.4"
 )
 ```
 
@@ -45,7 +45,7 @@ PB.targets in Compile := Seq(
 
 resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
-libraryDependencies += "beyondthelines" %% "grpcgatewayruntime" % "0.0.3" % "compile,protobuf"
+libraryDependencies += "beyondthelines" %% "grpcgatewayruntime" % "0.0.4" % "compile,protobuf"
 ```
 
 ### Usage

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val commonSettings = Seq(
   organization := "beyondthelines",
-  version := "0.0.3",
+  version := "0.0.4",
   licenses := ("MIT", url("http://opensource.org/licenses/MIT")) :: Nil,
   bintrayOrganization := Some("beyondthelines"),
   bintrayPackageLabels := Seq("scala", "protobuf", "grpc"),

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val commonSettings = Seq(
   organization := "beyondthelines",
-  version := "0.0.2",
+  version := "0.0.4",
   licenses := ("MIT", url("http://opensource.org/licenses/MIT")) :: Nil,
   bintrayOrganization := Some("beyondthelines"),
   bintrayPackageLabels := Seq("scala", "protobuf", "grpc"),

--- a/runtime/src/main/scala/grpcgateway/handlers/GrpcGatewayHandler.scala
+++ b/runtime/src/main/scala/grpcgateway/handlers/GrpcGatewayHandler.scala
@@ -14,44 +14,47 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 @Sharable
-abstract class GrpcGatewayHandler(channel: ManagedChannel)(implicit ec: ExecutionContext)
-  extends ChannelInboundHandlerAdapter {
+abstract class GrpcGatewayHandler(channel: ManagedChannel)(implicit ec: ExecutionContext) extends ChannelInboundHandlerAdapter {
 
   def name: String
 
   def shutdown(): Unit =
     if (!channel.isShutdown) channel.shutdown()
 
+  def supportsCall(method: HttpMethod, uri: String): Boolean
   def unaryCall(method: HttpMethod, uri: String, body: String): Future[GeneratedMessage]
 
   override def channelRead(ctx: ChannelHandlerContext, msg: scala.Any): Unit = msg match {
     case req: FullHttpRequest =>
       val body = req.content().toString(StandardCharsets.UTF_8)
-      unaryCall(req.method(), req.uri(), body)
-        .map(JsonFormat.toJsonString)
-        .map(_.getBytes(StandardCharsets.UTF_8))
-        .onComplete {
-          case Success(json) =>
-            val res = new DefaultFullHttpResponse(
-              req.protocolVersion(),
-              HttpResponseStatus.OK,
-              Unpooled.copiedBuffer(json)
-            )
-            res.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json")
-            HttpUtil.setContentLength(res, json.length)
-            HttpUtil.setKeepAlive(res, HttpUtil.isKeepAlive(req))
-            ctx.writeAndFlush(res)
+      if (supportsCall(req.method(), req.uri())) {
+        unaryCall(req.method(), req.uri(), body)
+          .map(JsonFormat.toJsonString)
+          .map(_.getBytes(StandardCharsets.UTF_8))
+          .onComplete {
+            case Success(json) =>
+              val res = new DefaultFullHttpResponse(
+                req.protocolVersion(),
+                HttpResponseStatus.OK,
+                Unpooled.copiedBuffer(json)
+              )
+              res.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json")
+              HttpUtil.setContentLength(res, json.length)
+              HttpUtil.setKeepAlive(res, HttpUtil.isKeepAlive(req))
+              ctx.writeAndFlush(res)
 
-          case Failure(e) =>
-            val status = e match {
-              case _: UnsupportedOperationException => HttpResponseStatus.NOT_FOUND
-              case _: NoSuchElementException => HttpResponseStatus.BAD_REQUEST
-              case _ => HttpResponseStatus.INTERNAL_SERVER_ERROR
-            }
-            val res = new DefaultHttpResponse(req.protocolVersion(), status)
-            ctx.writeAndFlush(res).addListener(ChannelFutureListener.CLOSE)
-        }
-
+            case Failure(e) =>
+              val status = e match {
+                case _: UnsupportedOperationException => HttpResponseStatus.NOT_FOUND
+                case _: NoSuchElementException        => HttpResponseStatus.BAD_REQUEST
+                case _                                => HttpResponseStatus.INTERNAL_SERVER_ERROR
+              }
+              val res = new DefaultHttpResponse(req.protocolVersion(), status)
+              ctx.writeAndFlush(res).addListener(ChannelFutureListener.CLOSE)
+          }
+      } else {
+        super.channelRead(ctx, msg)
+      }
     case _ => super.channelRead(ctx, msg)
   }
 }


### PR DESCRIPTION
There was a bug preventing the gateway to work in the presence of multiple services: the first handler would always try to handle all requests. I have added a generated `supportsCall` method which checks whether the handler is able to handle the call, if not thus forwarding the call to the next handler in pipeline.