### PR TITLE
fix PUT method gateway generation

### DIFF
--- a/generator/src/main/scala/grpcgateway/generators/GatewayGenerator.scala
+++ b/generator/src/main/scala/grpcgateway/generators/GatewayGenerator.scala
@@ -168,7 +168,7 @@ object GatewayGenerator extends protocbridge.ProtocCodeGenerator with Descriptor
           .add(s"""case ("PUT", "${http.getPut}") => """)
           .add("for {")
           .addIndented(
-            s"""msg <- Future.fromTry(JsonFormat.fromJsonString[${method.getInputType.getName}](body).recoverWith(jsonException2GatewayExceptionPF))""",
+            s"""msg <- Future.fromTry(Try(JsonFormat.fromJsonString[${method.getInputType.getName}](body)).recoverWith(jsonException2GatewayExceptionPF))""",
             s"res <- stub.$methodName(msg)"
           )
           .add("} yield res")


### PR DESCRIPTION
Hi! I run into issue with "put" methods. Method "recoverWith" is defined in Try.  
This small patch supposed to fix it.