### PR TITLE
Many actions (GET, DELETE, etc) to one path (/v1/some/entity)

### DIFF
--- a/generator/src/main/scala/grpcgateway/generators/GatewayGenerator.scala
+++ b/generator/src/main/scala/grpcgateway/generators/GatewayGenerator.scala
@@ -168,7 +168,7 @@ object GatewayGenerator extends protocbridge.ProtocCodeGenerator with Descriptor
           .add(s"""case ("PUT", "${http.getPut}") => """)
           .add("for {")
           .addIndented(
-            s"""msg <- Future.fromTry(JsonFormat.fromJsonString[${method.getInputType.getName}](body).recoverWith(jsonException2GatewayExceptionPF))""",
+            s"""msg <- Future.fromTry(Try(JsonFormat.fromJsonString[${method.getInputType.getName}](body)).recoverWith(jsonException2GatewayExceptionPF))""",
             s"res <- stub.$methodName(msg)"
           )
           .add("} yield res")


### PR DESCRIPTION
Hi! It fails if I try to assign the same path to many actions.

This patch groups generated methods by path and makes it possible:
![image](https://user-images.githubusercontent.com/6050271/34310239-04d21fde-e75f-11e7-8ea2-3aa5d0dc5917.png)


p.s. I would appreciate if you release 0.0.8