### PR TITLE
Add support for REST to GRPC header pass through

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,15 @@
 import scalapb.compiler.Version.{grpcJavaVersion, scalapbVersion}
 
 organization in ThisBuild := "beyondthelines"
-version in ThisBuild := "0.0.9"
+version in ThisBuild := "0.0.10"
 licenses in ThisBuild := ("MIT", url("http://opensource.org/licenses/MIT")) :: Nil
 bintrayOrganization in ThisBuild := Some("beyondthelines")
 bintrayPackageLabels in ThisBuild := Seq("scala", "protobuf", "grpc")
-scalaVersion in ThisBuild := "2.12.8"
+scalaVersion in ThisBuild := "2.12.10"
 
 lazy val runtime = (project in file("runtime"))
   .settings(
-    crossScalaVersions := Seq("2.12.8", "2.11.12"),
+    crossScalaVersions := Seq("2.12.10", "2.11.12"),
     name := "GrpcGatewayRuntime",
     libraryDependencies ++= Seq(
       "com.thesamet.scalapb"   %% "compilerplugin"          % scalapbVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.2.7
+sbt.version=1.3.3
 

--- a/runtime/src/main/scala/grpcgateway/handlers/GrpcGatewayHandler.scala
+++ b/runtime/src/main/scala/grpcgateway/handlers/GrpcGatewayHandler.scala
@@ -2,14 +2,24 @@ package grpcgateway.handlers
 
 import java.nio.charset.StandardCharsets
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import io.grpc.ManagedChannel
+import io.grpc.Metadata
+import io.grpc.stub.AbstractStub
+import io.grpc.stub.MetadataUtils
+import io.netty.channel.ChannelHandler.Sharable
+import io.netty.channel.ChannelFutureListener
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
+import io.netty.handler.codec.http._
 import scalapb.GeneratedMessage
 import scalapb.json4s.JsonFormat
-import io.grpc.ManagedChannel
-import io.netty.channel.ChannelHandler.Sharable
-import io.netty.channel.{ ChannelFutureListener, ChannelHandlerContext, ChannelInboundHandlerAdapter }
-import io.netty.handler.codec.http._
+import scala.collection.JavaConverters._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import grpcgateway.handlers.GrpcGatewayHandler.RestToGrpcPassThroughHeaders
+
 
 @Sharable
 abstract class GrpcGatewayHandler(channel: ManagedChannel)(implicit ec: ExecutionContext) extends ChannelInboundHandlerAdapter {
@@ -20,18 +30,17 @@ abstract class GrpcGatewayHandler(channel: ManagedChannel)(implicit ec: Executio
     if (!channel.isShutdown) channel.shutdown()
 
   def supportsCall(method: HttpMethod, uri: String): Boolean
-  def unaryCall(method: HttpMethod, uri: String, body: String): Future[GeneratedMessage]
+  def unaryCall(method: HttpMethod, uri: String, headers: HttpHeaders, body: String): Future[GeneratedMessage]
 
   override def channelRead(ctx: ChannelHandlerContext, msg: scala.Any): Unit = {
 
     msg match {
       case req: FullHttpRequest =>
-
         if (supportsCall(req.method(), req.uri())) {
 
           val body = req.content().toString(StandardCharsets.UTF_8)
 
-          unaryCall(req.method(), req.uri(), body)
+          unaryCall(req.method(), req.uri(), req.headers(), body)
             .map(JsonFormat.toJsonString)
             .map(json => {
               buildFullHttpResponse(
@@ -64,4 +73,43 @@ abstract class GrpcGatewayHandler(channel: ManagedChannel)(implicit ec: Executio
       case _ => super.channelRead(ctx, msg)
     }
   }
+
+  protected def stubWithHeaders[StubType <: AbstractStub[StubType]](stub: StubType, headers: HttpHeaders): StubType = {
+    val passThroughHeaders = headers.entries().asScala.collect {
+      case entry if RestToGrpcPassThroughHeaders.contains(entry.getKey) =>
+        (entry.getKey, entry.getValue)
+    }
+
+    if (passThroughHeaders.isEmpty) stub else {
+      val metadata = new Metadata()
+      passThroughHeaders.foreach { case (headerName, headerValue) =>
+        val metadataKey = Metadata.Key.of(headerName, Metadata.ASCII_STRING_MARSHALLER)
+        metadata.put(metadataKey, headerValue)
+      }
+      MetadataUtils.attachHeaders[StubType](stub, metadata)
+    }
+  }
+}
+
+object GrpcGatewayHandler {
+  private val RestToGrpcPassThroughHeaders: Set[String] = {
+    val envVarName = "REST_TO_GRPC_PASS_THROUGH_HEADERS"
+
+    Option(System.getenv(envVarName))
+      .map { str =>
+        val headers = str.split("""\s*,\s*""").toSet
+
+        val asciiEncoder = StandardCharsets.US_ASCII.newEncoder()
+        headers.foreach { header =>
+          if (header.isEmpty) {
+            throw new IllegalArgumentException(s"The empty string is not a legal header name; cannot process '$str' loaded from env variable $envVarName")
+          } else if (!asciiEncoder.canEncode(header)) {
+            throw new IllegalArgumentException(
+              s"Found non ASCII header '$header' in headers loaded from env variable $envVarName. Only ASCII headers are supported")
+          }
+        }
+
+        headers
+      }
+  }.getOrElse(Set.empty)
 }

--- a/runtime/src/main/scala/grpcgateway/handlers/GrpcGatewayHandler.scala
+++ b/runtime/src/main/scala/grpcgateway/handlers/GrpcGatewayHandler.scala
@@ -75,10 +75,13 @@ abstract class GrpcGatewayHandler(channel: ManagedChannel)(implicit ec: Executio
   }
 
   protected def stubWithHeaders[StubType <: AbstractStub[StubType]](stub: StubType, headers: HttpHeaders): StubType = {
-    val passThroughHeaders = headers.entries().asScala.collect {
-      case entry if RestToGrpcPassThroughHeaders.contains(entry.getKey) =>
-        (entry.getKey, entry.getValue)
-    }
+    val passThroughHeaders =
+      if (RestToGrpcPassThroughHeaders.isEmpty) Seq.empty else {
+        headers.entries().asScala.collect {
+          case entry if RestToGrpcPassThroughHeaders.contains(entry.getKey) =>
+            (entry.getKey, entry.getValue)
+        }
+      }
 
     if (passThroughHeaders.isEmpty) stub else {
       val metadata = new Metadata()

--- a/runtime/src/main/scala/grpcgateway/handlers/GrpcGatewayHandler.scala
+++ b/runtime/src/main/scala/grpcgateway/handlers/GrpcGatewayHandler.scala
@@ -19,6 +19,7 @@ import scalapb.json4s.JsonFormat
 import scala.collection.JavaConverters._
 
 import grpcgateway.handlers.GrpcGatewayHandler.RestToGrpcPassThroughHeaders
+import scalapb.json4s.Printer
 
 
 @Sharable
@@ -41,7 +42,7 @@ abstract class GrpcGatewayHandler(channel: ManagedChannel)(implicit ec: Executio
           val body = req.content().toString(StandardCharsets.UTF_8)
 
           unaryCall(req.method(), req.uri(), req.headers(), body)
-            .map(JsonFormat.toJsonString)
+            .map(printer.print)
             .map(json => {
               buildFullHttpResponse(
                 requestMsg = req,
@@ -92,6 +93,8 @@ abstract class GrpcGatewayHandler(channel: ManagedChannel)(implicit ec: Executio
       MetadataUtils.attachHeaders[StubType](stub, metadata)
     }
   }
+
+  private val printer = new Printer(includingDefaultValueFields = true)
 }
 
 object GrpcGatewayHandler {


### PR DESCRIPTION
This is a first sketch to adapt the implementation to allow passing through selected headers from REST calls to the corresponding GRPC calls. This PR introduces the environment variable `REST_TO_GRPC_PASS_THROUGH_HEADERS` that can be used to define headers that are passed through unmodified from REST to GRPC metadata.


What is still missing is
* documentation
* fail on server startup and not on the first request for broken `REST_TO_GRPC_PASS_THROUGH_HEADERS`

Before taking care of the remaining issues I would like to hear your feedback though.